### PR TITLE
chore: bump version to 1.0.0 to match release tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opportify_sdk"
-version = "0.3.1"
+version = "1.0.0"
 description = "Opportify Insights API"
 authors = ["OpenAPI Generator Community <team@openapitools.org>"]
 license = "NoLicense"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 NAME = "opportify_sdk"
-VERSION = "0.3.1"
+VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 3.0.0",


### PR DESCRIPTION
## Problem

The `v1.0.0` GitHub release was published, triggering the publish workflow. However, `pyproject.toml` and `setup.py` still had `version = "0.3.1"`. PyPI rejected the upload with `400 Bad Request` because `opportify_sdk==0.3.1` already exists on PyPI from the previous `v0.3.1` release — you cannot overwrite an existing version.

## Fix

Bump the version to `1.0.0` in both `pyproject.toml` and `setup.py` to match the `v1.0.0` git tag.

## Next Steps

After merging, re-run or re-publish the `v1.0.0` release to trigger a fresh publish workflow run.